### PR TITLE
Fix heating mode stuck in cut

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ condition:
   - condition: state
     entity_id: input_select.heating_mode_kitchen
     state: cut
+    for: '00:11:55'
 action:
   - choose:
       - conditions:

--- a/README.md
+++ b/README.md
@@ -326,8 +326,6 @@ trigger:
     entity_id: input_select.heating_mode_kitchen
     to: cut
     for: '00:12:00'
-  - platform: homeassistant
-    event: start
 condition:
   - condition: state
     entity_id: input_select.heating_mode_kitchen

--- a/README.md
+++ b/README.md
@@ -332,10 +332,22 @@ condition:
   - condition: state
     entity_id: input_select.heating_mode_kitchen
     state: cut
-  - condition: state
-    entity_id: input_boolean.heating_maintaince_kitchen
-    state: 'off'
 action:
+  - choose:
+      - conditions:
+          - condition: not
+            conditions:
+              - condition: state
+                entity_id: input_boolean.heating_maintaince_kitchen
+                state: 'off'
+        sequence:
+          - wait_for_trigger:
+              - platform: state
+                entity_id: input_boolean.heating_maintaince_kitchen
+                to: 'off'
+            timeout: '00:15:00'
+            continue_on_timeout: false
+    default: []
   - service: input_select.select_option
     data:
       option: default

--- a/README.md
+++ b/README.md
@@ -326,6 +326,8 @@ trigger:
     entity_id: input_select.heating_mode_kitchen
     to: cut
     for: '00:12:00'
+  - platform: time_pattern
+    minutes: /15
 condition:
   - condition: state
     entity_id: input_select.heating_mode_kitchen

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ action:
               - platform: state
                 entity_id: input_boolean.heating_maintaince_kitchen
                 to: 'off'
-            timeout: '00:15:00'
+            timeout: '00:11:55'
             continue_on_timeout: false
     default: []
   - service: input_select.select_option


### PR DESCRIPTION
#### fix cut-mode stuck indefinitely if the automation tasks gets reloaded

If you change and save any automation task and the heating would be in cut-mode, there would be no return from this mode until you either restart ha or the next time the maintenance task would run

#### avoid that the 'cut-mode end' task doesn't start when in maintenance mode

instead, wait till the end of maintenance mode and protect the heat cycle for 3 minutes. Important since there's basically no heat while running maintenance mode going on. Else it could the heat for another 12 minutes, which is undesirable.

#### minor changes:

- fix unnecessary task call: the cut-mode ending task doesn't need to run on ha-startup